### PR TITLE
vuln fix

### DIFF
--- a/2024/Cargo.toml
+++ b/2024/Cargo.toml
@@ -12,7 +12,7 @@ image = "0.25.5"
 imageproc = "0.25.0"
 indicatif = { version = "0.17.9", features = ["rayon"]}
 lazy_static = "1.5.0"
-lru = "0.12.5"
+lru = "0.16.3"
 ndarray = "0.16.1"
 pathfinding = "4.12.0"
 rayon = "1.10.0"

--- a/2025/Cargo.toml
+++ b/2025/Cargo.toml
@@ -21,7 +21,7 @@ tempfile = "3.14.0"
 
 # useful crates from prior years
 #rayon = "1.10.0"
-#lru = "0.12.5"
+#lru = "0.16.3"
 
 [[bin]]
 name = "advent_of_code_2025"


### PR DESCRIPTION
fix: upgrade lru to 0.16.3 to resolve GHSA-rhfx-m35p-ff5j soundness vulnerability

- 2024/Cargo.toml: lru 0.12.5 -> 0.16.3
- 2025/Cargo.toml: update commented-out lru reference to 0.16.3